### PR TITLE
options are mixedCase rather than CamelCase

### DIFF
--- a/tutorials/pisoFoamHFDIB/cylinder/system/controlDict
+++ b/tutorials/pisoFoamHFDIB/cylinder/system/controlDict
@@ -43,9 +43,9 @@ timeFormat      general;
 
 timePrecision   6;
 
-MaxCo           1.0;
+maxCo           1.0;
 
-MaxDeltaT       0.0001;
+maxDeltaT       0.0001;
 
 adjustableTimeStep  true;
 


### PR DESCRIPTION
maxCo and maxDeltaT.  I don't think that they're actually used yet in pisoFoamHFDIB, but the CamelCase ones don't exist anywhere.